### PR TITLE
Change emphasis away from Exporter toward two way nature of Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-**Needle Engine** is a web-based runtime for 3D apps. It runs on your machine for development, and can be deployed anywhere. It is flexible, extensible and has built-in support for collaboration and XR! 
+**Needle Engine** is a web-based runtime for 3D apps. It runs on your machine for development, and can be deployed anywhere. It is flexible, extensible and has built-in support for collaboration and XR! It uses three.js and Typescript to implement a run time game engine that goes a long way toward implementing most of the functionality of the Unity runtime engine.
 
-**Needle Exporter for Unity** bridges the Unity Editor and the web runtime. It helps you to export your assets, animations, lightmaps and so on to the web. It is built around the glTF standard for 3D assets.  
+**Needle Tools for Unity** bridges the Unity Editor and the web runtime. It helps you to export your assets, animations, lightmaps and 3D scene graph to the web and it helps you bring your TypeScript and three.js based code into Unity so it can be triggered by Unity events and configured in the Unity inspector like built in Unity components.
+It is built around the glTF standard for 3D assets and uses the gLTF extension mechanism to store the properties you see in the unity inspector so they can be used at runtime by the Needle Engine.  
 
-**Together**, they enable incredible iteration speeds and help you to bring your content to the web.  
+**Together**, they enable incredible iteration speeds and help you to bring your content to the web. 
 Some have called it the "Missing Link" between artist-friendly workflows and modern web development!
 
 Visit the docs at [engine.needle.tools/docs](https://engine.needle.tools/docs)

--- a/documentation/audiences.md
+++ b/documentation/audiences.md
@@ -1,0 +1,30 @@
+---
+title: Getting Up To Speed
+---
+
+# Getting Up To Speed
+
+Needle Engine is of interest to a number of different audiences. Here is how each of them can get the most out of Needle Tools.
+
+## Unity Developers
+
+Unity developers are already familiar with using Unity components and wiring scene graphs together using the Unity editor. 
+Needle Engine allows them to export their Unity scenes to web browser based scenes using the Needle runtime to implement many Unity game engine features.
+
+Unity developers will benefit from learning about the core web technologies used by the runtime engine such as Typescript and three.js. To work with Needle tiny networking, they will benefit from learning about nodel.js.
+
+An excellent resource to learn the above skills is Bruno Simon's excellent [Three.js Journey](https://threejs-journey.com)
+
+## Web Developers
+
+Web developers are already familiar with using Typescript and three.js to implement 3D scenes that run in a web browser.
+
+Needle Engine allows them to create Unity wrappers for their typescript code so that it is able to be treated as Unity components in the Unity editor. 
+
+Web developers will benefit from learning the basics of using the unity editor, but need not concern themselves with learning much about unity scripting with C#.
+
+## Blender Artists
+
+Blender artists are familiar with how to use Blender to create 3D scenes for export to the web. Needle Tools for Blender adds new components to the Blender UI that allow Blender scenes to be exported directly to a Needle engine based scene that runs in any modern web browser. 
+
+The new components allow dynamic behaviours to be added to the scene.

--- a/documentation/component-reference.md
+++ b/documentation/component-reference.md
@@ -1,18 +1,22 @@
 # Component Reference 🧩
 
-Here is a overview of some of the components that we provide. Some of them map directly to Unity components, while others are core components from Needle Engine.   
+Here is a overview of some of the components that we provide. Some of them map directly to Unity components, while others are core components from Needle Engine. For Unity components, there may be an additional component called ???Data. These Data components contain additional parameters beyond the built in Unity components since we can't modify their inspector properties directly.
 For a complete list please have a look at the components inside the folders ``node_modules/@needle-tools/engine/engine-components`` and ``engine-components-experimental``.  
 
 > You can always add your own components or add wrappers for Unity components we haven't provided yet.  
 > Read more in the [Scripting](./scripting.md) section of our docs.
 
 ## Audio
+Audio is implemented using a custom mixer in the Needle runtime engine.  
+
 | Name  | Description |
 | ------------- | ------------- |
-| AudioListener |  |
-| AudioSource |  |
+| AudioListener |  Maps the standard Unity Audiolistener parameters to web browser audio. |
+| AudioSource |  Maps a Unity audio source to a web base audio source. |
 
 ## Animation
+Animation is implemented using custom code the Needle runtime engine.  
+
 | Name  | Description |
 | ------------- | ------------- |
 | Animator + AnimatorController | Export with animation state machine, conditions, transitions  |
@@ -20,16 +24,20 @@ For a complete list please have a look at the components inside the folders ``no
 | PlayableDirector + Timeline | Export powerful sequences to control animation, audio, state and more |
 
 ## Rendering
+Rendering is implemented using WebGL and WebXR code in the Needle runtime engine.  
+
 | Name  | Description |
 | ------------- | ------------- |
-| Camera |  |
-| LODGroup |  |
-| Light |  |
+| Camera | Maps Unity camera to a standard three.js camera. |
+| LODGroup | Creates an LOD Group |
+| Light | Maps Unity light to one of the standard three.js lights |
 | ParticleSystem | Experimental and currently not fully supported |
 | XRFlag | Control when objects will be visible. E.g. only enable object when in AR  |
 | VideoPlayer  | Playback videos from url or referenced video file (will be copied to output on export) |
 
 ## Networking
+Networking is implemented in the Needle runtime engine and requires a Needle Tiny Server. 
+
 | Name  | Description |
 | ------------- | ------------- |
 | SyncedRoom | Main networking component. Put in your scene to enable networking |
@@ -40,17 +48,19 @@ For a complete list please have a look at the components inside the folders ``no
 | Voip | Enables voice-chat |
 
 ## Interaction
+Interaction is implemented in the Needle runtime engine. Some features below may require a Needle tiny server for fullfunctionallity.
+
 | Name  | Description |
 | ------------- | ------------- |
 | EventSystem |  |
-| ObjectRaycater | Required for DragControls and Duplicatable |
-| DragControls | Requires raycaster in parent hierarchy, e.g. ObjectRaycaster |
-| Duplicatable | Requires DragControls |
+| ObjectRaycaster | Adds a three.js raycaster that casts rays into it's child hierarchy. Required for DragControls and Duplicatable |
+| DragControls | Allos an object to be dragged. Requires ObjectRaycaster in parent hierarchy |
+| Duplicatable | Works with DragControls to make an object cloneable by dragging. Requires DragControls |
 | Interactable | Basic component to mark an object to be interactable. |
-| OrbitControls | Add to camera to add camera orbit control functionality |
+| OrbitControls | Add to camera to add camera orbit control functionality using three.js OrbitControls |
 | SmoothFollow | Allows to interpolate smoothly to another object's transform |
 | DeleteBox |  |
-| DropListener | Add to receive file drop events for uploading |
+| DropListener | Add to receive file drop events for uploading to a Needle tiny storage server |
 | SpatialTrigger | Use to raise event if an object enters a specific space or area |
 | SpatialTriggerReceiver | Use to receive events from SpatialTrigger |
 
@@ -60,11 +70,11 @@ Physics is implemented using [rapier](https://rapier.rs/).
 
 | Name  | Description |
 | ------------- | ------------- |
-| Rigidbody | |
-| BoxCollider |  |
-| SphereCollider |  |
-| CapsuleCollider |  |
-| MeshCollider |  |
+| Rigidbody | Maps to a Rapier Rigidbody|
+| BoxCollider | Creates a Rapier box collider |
+| SphereCollider |  Creates a Rapier box collider  |
+| CapsuleCollider | Creates a Rapier box collider   |
+| MeshCollider | Creates a Rapier mesh collider   |
 | [Physics Materials](https://docs.unity3d.com/Manual/class-PhysicMaterial.html) | Physics materials can be used to define e.g. the bouncyness of a collider |
 
 ## XR / WebXR  
@@ -80,17 +90,23 @@ Physics is implemented using [rapier](https://rapier.rs/).
 | WebARSessionRoot | Put your AR content inside a WebARSessionRoot for placement and scale |
 
 ## Debugging  
+
+Implemented using standard three.js helpers.
+
 | Name  | Description |
 | ------------- | ------------- |
-| GridHelper | Draws a grid |
-| BoxGizmo | Draws a box |
-| AxesHelper | Draws axes |
+| GridHelper | Draws a three.js grid |
+| BoxGizmo | Draws a three.js box |
+| AxesHelper | Draws three.hs axes |
 
 ## Runtime File Input/Output  
+
+These features are still experimental.
+
 | Name  | Description |
 | ------------- | ------------- |
-| GltfExport | Experimental! Use to export gltf from web runtime. |
-| DropListener | Receive file drop events for uploading and networking |
+| GltfExport | Use to export gltf from web runtime. |
+| DropListener | Receive file drop events for uploading and networking, Requires Needle tiny storage server |
 
 ## UI
 

--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -6,11 +6,13 @@ next: deployment.md
 
 # Getting started 🎈
 
-These steps will get you started with **Needle Engine for Unity**.  
-After following them, you'll have a fully functional project.  
-From here, you can dive deeper into [Scripting](./scripting.md), [VR and AR](./xr.md), [Networking](./networking.md), or the various [Samples and Modules](./samples-and-modules.md).  
+To get an idea for what kind of things are possible using Needle Tools, check out the  [Samples and Modules](./samples-and-modules.md).  
 
-You can either watch our Getting Started video or continue reading below 😊   
+Once you're ready to start your own project, the steps below will get you started with **Needle Engine** and **Needle Tools for Unity**.  
+After following them, you'll have a fully functional project.
+From there, you can dive deeper into [Scripting](./scripting.md), [VR and AR](./xr.md) or [Networking](./networking.md)
+
+You can watch our Getting Started video and follow along with the instructions below 😊   
 <video-embed src="https://www.youtube.com/watch?v=3dB-d1Jo_Mk" limit_height />
 
 ## Quick Start ⚡
@@ -24,11 +26,11 @@ You can either watch our Getting Started video or continue reading below 😊
 1. **Download our installer**  
     <needle-button href="https://engine.needle.tools/downloads/unity"><strong>Download Needle Engine for Unity</strong></needle-button>  • [Alternative](https://package-installer.glitch.me/v1/installer/needle/com.needle.engine-exporter?registry=https://packages.needle.tools&scope=com.needle&scope=org.khronos)   
 
-    Our installer is a `.unitypackage` that will set everything up for you.  
+    Our installer is a `.unitypackage` that will set everything up for you. It is very small, and it rarely changes. It contains just enough code to download and install Needle packages from our code registry. 
   
 1. **Install by dropping into Unity**   
    Drop the downloaded `.unitypackage` file into a Unity project and confirm that you want to import it.  
-   This will set up Needle Engine and Needle Exporter for Unity.  
+   This will download the latest version of Needle Engine and Needle Tools for Unity directly from our custom package registry.
 
 2. **Wait for the installation to finish**  
    You may have to click _Assets > Refresh_ once or focus another app and then focus Unity again.  
@@ -45,11 +47,13 @@ You can either watch our Getting Started video or continue reading below 😊
 
 ### Create a new project
 
-1. **Set up a new project**  
+1. **Make sure node.js and Unity are installed - <a href="#prerequisites">see details</a>**  
+
+2. **Set up a new project**  
 Create a new Unity project via the [Hub](https://docs.unity3d.com/hub/manual/index.html).  
 We recommend 2021.3 LTS. Make sure to switch to Linear color space!  
 
-2. **Add our registry to Package Manager**  
+3. **Add our registry to Package Manager**  
 Open ``Edit/Project Settings`` and select ``Package Manager``.  
 Add a new [scoped registry](https://docs.unity3d.com/Manual/upm-scoped.html):
     - Name: ``needle``
@@ -60,7 +64,7 @@ Add a new [scoped registry](https://docs.unity3d.com/Manual/upm-scoped.html):
   ![image](https://user-images.githubusercontent.com/2693840/186287175-0de831b8-9112-43fa-989d-c13680186ff0.png)
 
 
-3. **Add the Exporter package**  
+4. **Add the Exporter package**  
 Open the [Unity Package Manager](https://docs.unity3d.com/Manual/upm-ui.html) via ``Window/Package Manager``.  
 In the dropdown in top left corner of the window select ``My Registries``.  
 Select ``Needle Engine Exporter`` and click install in the bottom right corner.  
@@ -103,14 +107,14 @@ By default, the project name matches the name of your scene. If you want to chan
 
 ## Generate a web project and add content
 
-Needle Engine is a web-based runtime, and so there's always two projects: your Unity project and a web project that contains regular HTML and CSS. Needle Exporter brings these together into a fast, iterative workflow.  
+Needle Engine is a web-based runtime, and so there's always two projects: your Unity project and a web project that contains regular HTML, Jaascript, Typescript and CSS. Needle Exporter brings these together into a fast, iterative workflow.  
 Usually, one Unity Scene with `ExportInfo` has one web project, so we're going to generate one now.  
 
 1. **Generate your web project**   
   On the `ExportInfo` component, click ``Generate Project``.   
   Wait a moment for the installation to finish — you can see a progress indicator in the bottom right corner of the editor.  
 
-1. **View your project in a browser**
+2. **View your project in a browser**
   After a few seconds of installation, your project should automatically run and a new browser window opens. 
   
 ::: tip Note
@@ -124,6 +128,7 @@ Keep an eye for console warnings! We log useful details about recommended projec
 :::
 
 ⭐ **Congratulations!**  You just started your first project using Needle Engine! We're excited what you'll build.  
+If you did the quick start and chose the collaborative sandbox example to start with, you might want to go back and generate a new project from scratch before proceeding with the steps below to add content.
 
 ------------
 

--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -12,10 +12,10 @@ Once you're ready to start your own project, the steps below will get you starte
 After following them, you'll have a fully functional project.
 From there, you can dive deeper into [Scripting](./scripting.md), [VR and AR](./xr.md) or [Networking](./networking.md)
 
-You can watch our Getting Started video and follow along with the instructions below 😊   
-<video-embed src="https://www.youtube.com/watch?v=3dB-d1Jo_Mk" limit_height />
+## Get Ready
 
-## Quick Start ⚡
+The first set of instructions is the same no matter if you want to start with one of our scene
+templates, one of our sample projects, or create your own needle tools based app from scratch.
 
 1. **Make sure node.js and Unity are installed - <a href="#prerequisites">see details</a>**  
 
@@ -23,60 +23,41 @@ You can watch our Getting Started video and follow along with the instructions b
   Open Unity Hub and create a new project. 2021.3 recommended!  
   Make sure to switch it to Linear color space in `Project Settings > Player`.
   
-1. **Download our installer**  
+3. **Download our installer**  
     <needle-button href="https://engine.needle.tools/downloads/unity"><strong>Download Needle Engine for Unity</strong></needle-button>  • [Alternative](https://package-installer.glitch.me/v1/installer/needle/com.needle.engine-exporter?registry=https://packages.needle.tools&scope=com.needle&scope=org.khronos)   
 
     Our installer is a `.unitypackage` that will set everything up for you. It is very small, and it rarely changes. It contains just enough code to download and install Needle packages from our code registry. 
   
-1. **Install by dropping into Unity**   
+4. **Install by dropping into Unity**   
    Drop the downloaded `.unitypackage` file into a Unity project and confirm that you want to import it.  
    This will download the latest version of Needle Engine and Needle Tools for Unity directly from our custom package registry.
 
-2. **Wait for the installation to finish**  
+5. **Wait for the installation to finish**  
    You may have to click _Assets > Refresh_ once or focus another app and then focus Unity again.  
      > **Note**: A window may open stating that "A new scoped registry is now available in the Package Manager.". This is our Needle Package registry where packages are downloaded from. You can safely close that window.  
 
-3. **Create a new scene from a template**  
+
+## Collab Sandbox Showcase ⚡
+
+The collaborative sandbox example will show you how to quickly get a Needle Tools site up and running with all of the advanced components included. Watch our Getting Started video and follow along with the instructions below to build a fully functional networked example 😊   
+<video-embed src="https://www.youtube.com/watch?v=3dB-d1Jo_Mk" limit_height />
+
+1. **Create a new scene from the Collab Sandbox template**  
    Select _File > New Scene_ and choose from one of the Needle templates.  
    We recommend the [Collab Sandbox](https://needle-tiny-starter.glitch.me/) template which is a great way to get started with interactivity, multiplayer, and adding assets.  
 
-4. **Continue [here](#generate-a-web-project-and-add-content) to make it your own.**  
-   Learn how to iterate, test, build and publish your projects.  
+2. **Continue [here](#generate-a-web-project-and-add-content)** to learn how to build and deploy the project, then return here to continue with a more in depth look at how to build a Needle Tools app from scratch.
 
-## Option 2: Start from Scratch 🐢 — Manual Setup 
-
-### Create a new project
-
-1. **Make sure node.js and Unity are installed - <a href="#prerequisites">see details</a>**  
-
-2. **Set up a new project**  
-Create a new Unity project via the [Hub](https://docs.unity3d.com/hub/manual/index.html).  
-We recommend 2021.3 LTS. Make sure to switch to Linear color space!  
-
-3. **Add our registry to Package Manager**  
-Open ``Edit/Project Settings`` and select ``Package Manager``.  
-Add a new [scoped registry](https://docs.unity3d.com/Manual/upm-scoped.html):
-    - Name: ``needle``
-    - URL: ``https://packages.needle.tools``
-    - Scope(s):   
-      `com.needle`  
-      `org.khronos`  
-  ![image](https://user-images.githubusercontent.com/2693840/186287175-0de831b8-9112-43fa-989d-c13680186ff0.png)
-
-
-4. **Add the Exporter package**  
-Open the [Unity Package Manager](https://docs.unity3d.com/Manual/upm-ui.html) via ``Window/Package Manager``.  
-In the dropdown in top left corner of the window select ``My Registries``.  
-Select ``Needle Engine Exporter`` and click install in the bottom right corner.  
-
-::: tip Note
-You only need to install `Needle Engine Exporter` – other packages will automatically be installed as dependencies.  
-:::
+⭐ **Congratulations!**  You just started your first project using Needle Engine! We're excited what you'll build.  
+Next we will show you how to generate a new project from scratch and show you the steps below to add your own custom content.
 
 ### Create a new scene from a Scene Template
 
+1. Follow the steps in the Get Ready section to set up your project as a Needle Tools project.
+
 We provide a number of Scene Templates for quickly starting new projects.  
-These allow you to go from idea to prototype in a few clicks.  
+These allow you to go from idea to prototype in a few clicks.  You can
+use one of the scene templates by following the steps below.
 
 1. Click on `File > New Scene`
 2. Select one of the templates with (needle) in their name and click `Create`.
@@ -86,7 +67,7 @@ These allow you to go from idea to prototype in a few clicks.
 
 ### Create a new scene from scratch
 
-If you don't want to start from a scene template, you can follow these steps.  
+To create a scene from scratch, you can follow these steps.  
 Effectively, we're going to recreate the "Minimal (Needle)" template that's shipping with the package.  
 
 1. **Create a new empty scene**  
@@ -103,9 +84,36 @@ By default, the project name matches the name of your scene. If you want to chan
 3. **Choose a web project template**  
   Now, select a web project template for your project. The default template is based on [Vite](https://vitejs.dev/), a fast web app bundler.  
 
-4. **Continue [here](#generate-a-web-project-and-add-content)**.
+4. **Continue [here](#generate-a-web-project-and-add-content)** to learn how to build and deploy the project, then return here to continue with a more in depth look at how to build a Needle Tools app from scratch.
 
-## Generate a web project and add content
+5. **Add content**    
+   1. Create a new empty GameObject
+   1. Add a ``GltfObject`` component to it. This component marks parts of your hierarchy to be exported as glTF file. 
+   1. Add an object (e.g. ``Create/3D Object/Cube``) as a child to the ``GltfObject`` hierarchy and save. 
+   1. Your browser should refresh and your object is visible.
+
+6. **Make it interactive**  
+  Needle Engine comes with a set of [prebuilt components](./component-reference.md) that you can use to easily make your scene interactive. One of those components is ``OrbitControls``, which we're going to use to make the camera interactive.
+    1. Select your ``Main Camera`` GameObject
+    1. Add a new ``OrbitControls`` component to it 
+    1. Press play or save your scene
+    1. Your browser should refresh and you can now move the camera around.
+
+::: tip Note    
+**The local server does not start / no website in your browser?**  
+  Make sure you read and followed the [Prerequisites](#prerequisites-).  
+  Also check the console and `ExportInfo` component for warnings or errors.   
+  And last but not least, press `Play` to start the local server.  
+:::
+  
+
+::: tip Note    
+**No cube on your website?**   
+  Make sure it's a child of your GltfObject root.  
+:::
+
+------------
+## Generate a web project and view it in a browser
 
 Needle Engine is a web-based runtime, and so there's always two projects: your Unity project and a web project that contains regular HTML, Jaascript, Typescript and CSS. Needle Exporter brings these together into a fast, iterative workflow.  
 Usually, one Unity Scene with `ExportInfo` has one web project, so we're going to generate one now.  
@@ -127,39 +135,8 @@ If that happens: click ``Advanced`` and ``Proceed to Site``. Now you should see 
 Keep an eye for console warnings! We log useful details about recommended project settings and so on. For example, your project should be set to Linear color space (not Gamma), and we'll log an error if that's not the case.  
 :::
 
-⭐ **Congratulations!**  You just started your first project using Needle Engine! We're excited what you'll build.  
-If you did the quick start and chose the collaborative sandbox example to start with, you might want to go back and generate a new project from scratch before proceeding with the steps below to add content.
 
 ------------
-
-3. **Add content**    
-   1. Create a new empty GameObject
-   1. Add a ``GltfObject`` component to it. This component marks parts of your hierarchy to be exported as glTF file. 
-   1. Add an object (e.g. ``Create/3D Object/Cube``) as a child to the ``GltfObject`` hierarchy and save. 
-   1. Your browser should refresh and your object is visible.
-
-4. **Make it interactive**  
-  Needle Engine comes with a set of [prebuilt components](./component-reference.md) that you can use to easily make your scene interactive. One of those components is ``OrbitControls``, which we're going to use to make the camera interactive.
-    1. Select your ``Main Camera`` GameObject
-    1. Add a new ``OrbitControls`` component to it 
-    1. Press play or save your scene
-    1. Your browser should refresh and you can now move the camera around.
-
-::: tip Note    
-**The local server does not start / no website in your browser?**  
-  Make sure you read and followed the [Prerequisites](#prerequisites-).  
-  Also check the console and `ExportInfo` component for warnings or errors.   
-  And last but not least, press `Play` to start the local server.  
-:::
-  
-
-::: tip Note    
-**No cube on your website?**   
-  Make sure it's a child of your GltfObject root.  
-:::
-
-------------
-
 
 ## Prerequisites 💿
 

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -7,9 +7,10 @@ lastUpdated: false
 footer: "Copyright © 2022 Needle Tools GmbH"
 ---
 
-**Needle Engine** is a web-based runtime for 3D apps. It runs on your machine for development, and can be deployed anywhere. It is flexible, extensible and has built-in support for collaboration and XR! 
+**Needle Engine** is a web-based runtime for 3D apps. It runs on your machine for development, and can be deployed anywhere. It is flexible, extensible and has built-in support for collaboration and XR! It uses three.js and Typescript to implement a run time game engine that goes a long way toward implementing most of the functionality of the Unity runtime engine.
 
-**Needle Exporter for Unity** bridges the Unity Editor and the web runtime. It helps you to export your assets, animations, lightmaps and so on to the web. It is built around the glTF standard for 3D assets.  
+**Needle Tools for Unity** bridges the Unity Editor and the web runtime. It helps you to export your assets, animations, lightmaps and 3D scene graph to the web and it helps you bring your TypeScript and three.js based code into Unity so it can be triggered by Unity events and configured in the Unity inspector like built in Unity components.
+It is built around the glTF standard for 3D assets and uses the gLTF extension mechanism to store the properties you see in the unity inspector so they can be used at runtime by the Needle Engine.  
 
 **Together**, they enable incredible iteration speeds and help you to bring your content to the web.  
 Some have called it the "Missing Link" between artist-friendly workflows and modern web development!

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -7,13 +7,16 @@ lastUpdated: false
 footer: "Copyright © 2022 Needle Tools GmbH"
 ---
 
-**Needle Engine** is a web-based runtime for 3D apps. It runs on your machine for development, and can be deployed anywhere. It is flexible, extensible and has built-in support for collaboration and XR! It uses three.js and Typescript to implement a run time game engine that goes a long way toward implementing most of the functionality of the Unity runtime engine.
+  **Needle Engine** is a web client based runtime for 3D apps. It can be deployed to any modern web browser. It is flexible, extensible and has built-in support for collaboration and XR via the Needle Tiny Server! It uses three.js and Typescript to implement a run time game engine in your browser that goes a long way toward implementing most of the functionality of the Unity runtime engine.
 
-**Needle Tools for Unity** bridges the Unity Editor and the web runtime. It helps you to export your assets, animations, lightmaps and 3D scene graph to the web and it helps you bring your TypeScript and three.js based code into Unity so it can be triggered by Unity events and configured in the Unity inspector like built in Unity components.
-It is built around the glTF standard for 3D assets and uses the gLTF extension mechanism to store the properties you see in the unity inspector so they can be used at runtime by the Needle Engine.  
+**Needle Tools for Unity** bridges the Unity Editor and the Needle Engine. It helps you to export your Unity based assets, animations, lightmaps and 3D scene graph to the web and it helps you bring your TypeScript and three.js based code into Unity. Your TypeScript code can be triggered by Unity events and configured in the Unity inspector like built in Unity components.
+It features a world class gLTF exporter built around the glTF standard for 3D assets and uses the gLTF extension mechanism to store the properties you see in the unity inspector so they can be used at runtime by the Needle Engine.  
+
+**Needle Tiny Server** is a tiny node.js based server that implements many common networking features such as VOIP, webcam streaming, RPC messaging, room management, remote storage and network screen sharing. 
+You can use Needle Tools and the Needle Engine without a Needle Tiny Server, but for making networked experiences you will need a networking solution and Needle Tiny Server was designed to be a minimal and lightweight solution. Deploy a Needle Tiny Server directly to services like Glitch.io from the unity inspector or create your own custom deploy script to use whatever service you like.
 
 **Together**, they enable incredible iteration speeds and help you to bring your content to the web.  
-Some have called it the "Missing Link" between artist-friendly workflows and modern web development!
+Some have called us the "Missing Link" between artist-friendly workflows and modern web development!
 
 <actiongroup>
     <action href="getting-started">
@@ -25,15 +28,15 @@ Some have called it the "Missing Link" between artist-friendly workflows and mod
     <action href="testimonials">
     Testimonials 💬
     </action>
+    <action href="audiences">
+    Audiences 💬
+    </action>
     <action href="https://engine.needle.tools/samples">
     Samples 👀
     </action>
 </actiongroup>
 
-
 <video-embed src="https://user-images.githubusercontent.com/5083203/186121100-b02a83ef-a5df-42f9-a694-c445f1d82b81.mp4" />
- 
-
 
 <copyright></copyright>
 

--- a/documentation/networking.md
+++ b/documentation/networking.md
@@ -1,5 +1,7 @@
 # Networking
 
+Networking features require you to have a Needle Tools Network component in your scene graph that points to a Needle Tiny Server deployed on a server of your choice. Our deploy to glitch component can manage all of the setup for you.
+
 Access to core networking functionality can be obtained by using ``this.context.connection`` from a component. [The built-in backend server](https://glitch.com/edit/#!/needle-tiny-server) requires users to be connected to a room.
 
 Networking is currently based on [websockets](https://github.com/jjxxs/websocket-ts) and sending either json strings (for infrequent updates) or [flatbuffers](https://google.github.io/flatbuffers/) (for frequent updates).
@@ -100,11 +102,29 @@ When deploying your app to Glitch, we include a simple networking backend that i
 
 ### How to upgrade to a stronger server
 
-> 🏗️ Under construction.
+If you have your own server that can run a node.js app, you can use it instead of glitch. You will need to figure out the deployment details on your own, but you can use this as a guide.
+
+The default implementation for the Needle Tiny Server is here:
+
+https://glitch.com/edit/#!/needle-tiny-server?path=package.json%3A1%3A0
+
+You can create a VSCode project to connect to this glitch template and pull the code to a local folder on your own machine.
+
+You can then re-deploy the code to your own node.js server and arrange to run it there. Don't forget to update the URI in your scenes Network components to point at the new location.
+
+### How to run a local development server
+
+Follow the instructions above to download a copy of the default Needle Tiny Server from glitch.io to your local machine.
+
+Once you have the code on your local machine, run a local copy of the server using the START.BAT file or via 'npm run start'
+
+You can then point your Network components localhost parameter to the location of your running Needle Tiny Server.
 
 ### How to use your own networking implementation
 
-> 🏗️ Under construction.
+Follow the instructions above to download a copy of the default Needle Tiny Server from glitch.io to your local machine.
+
+Once you have the code on your local machine, you can look at the code in the src folder to see what the needle tiny server API provides. Write your own methods to implement the main functions in the tiny server so the existing networking features in the browser runtime engine will work seamlessly with your own code.
 
 ### How to change from the default ICE/STUN servers used for VoIP
 

--- a/documentation/technical-overview.md
+++ b/documentation/technical-overview.md
@@ -5,12 +5,13 @@
 ## How it works
 
 Needle Engine roughly consists of three parts:
-- a number of **components and tools** that allow you to set up scenes for Needle Engine from e.g. the Unity Editor.  
-- an **exporter** that turns scene and component data into glTF.
-- a **web runtime** that loads and runs the produced glTF files and their extensions.
+- a number of **components and tools** that allow developers to set up scenes for Needle Engine from the Unity Editor, including an **exporter** that turns scene and component data into glTF and a **component generator** that turns your three.js typescript code into Unity components.
+- a **web runtime** that loads and runs the produced glTF files and their extensions in the users web browser.
+- an optional **tiny node.js server** that implements networking features like file storage, VOIP, scene synchronization and RPC in the cloud
 
 The editor extensions currently support the Unity Editor, with some promising experiments for Blender on the horizon (but no ETA).  
 The web runtime uses three.js for rendering, adds a component system on top of the three scene graph and hooks up extension loaders for our custom glTF extensions.  
+The tiny server provides networking services such as VOIP, webcam streaming, RPC messaging, room management, remote storage and network screen sharing. 
 
 Effectively, this turns the Unity Editor into a full member of a regular web development toolchain – "just" one more piece that gets added to the regular HTML, JavaScript, CSS and bundling workflow.  
 


### PR DESCRIPTION
These changes are mainly about shifting the emphasis away from calling NT for Unity an exported and stating that it also lets you import components based on typescript IN to Unity.

Based on considering how to avoid some of the situations feedback was received about.

There were also some issues about the getting started workflow depending on there being two paths. If you started with the collar example, it might be confusing to add a cube to it. Also both paths need to install node.js and unity first so I added that to the second path and adjusted the numbering of the steps.