### PR TITLE
docs: include Vite and Next.js plugins in TypeDoc API docs build (NE-6952)

### DIFF
--- a/tools/api-plugins/tsconfig.json
+++ b/tools/api-plugins/tsconfig.json
@@ -27,7 +27,8 @@
       ]
     },
     "include": [
-      "../../.temp/**/src/**/*.ts"
+      "../../.temp/**/src/**/*.ts",
+      "../../.temp/**/plugins/types/**/*.ts"
     ],
     "exclude": ["node_modules", "dist", "lib", "vite.config.ts", "tests"]
   }

--- a/tools/build_api_docs.mjs
+++ b/tools/build_api_docs.mjs
@@ -244,6 +244,9 @@ async function produceDocs(packageDir, outputDirectory, hostedBaseUrl) {
             packageDir + "/src/engine-components/api.ts",
             packageDir + "/src/engine-components-experimental/api.ts",
             packageDir + "/src/engine-schemes/api.ts",
+            // Vite and Next.js plugin entry points
+            packageDir + "/plugins/types/vite.d.ts",
+            packageDir + "/plugins/types/next.d.ts",
         ],
         tsconfig: "./tools/api-plugins/tsconfig.json",
         // don't include references multiple times


### PR DESCRIPTION
## Summary

Companion to needle-tools/needle-tiny#923 — makes the Needle Engine Vite plugins visible in the public API documentation at `engine.needle.tools/docs/api`.

- **`tools/build_api_docs.mjs`** — adds `plugins/types/vite.d.ts` and `plugins/types/next.d.ts` as new TypeDoc entry points alongside the existing `src/engine/api.ts` entries.
- **`tools/api-plugins/tsconfig.json`** — extends the `include` glob with `../../.temp/**/plugins/types/**/*.ts` so TypeScript resolves plugin type imports correctly during the docs build.

After this change, TypeDoc will render a **Vite Plugins** module in the API docs showing `needlePlugins`, `loadConfig`, `useGzip`, and all ~24 individual sub-plugin exports — each with full JSDoc descriptions, parameter docs, return types, and usage examples.

## Test plan

- [ ] Run `node tools/build_api_docs.mjs --dev` locally; confirm no TypeDoc errors
- [ ] Check that the generated `api/` directory contains a page for the Vite plugins module
- [ ] Verify `needlePlugins` and `needlePWA` both appear with their full docstrings
- [ ] Spot-check that existing `src/` module pages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)